### PR TITLE
[Document feeding] Separate from deploy and use certificates

### DIFF
--- a/visual-retrieval-colpali/init-scripts/01-init.sql
+++ b/visual-retrieval-colpali/init-scripts/01-init.sql
@@ -21,8 +21,6 @@ CREATE TABLE user_settings (
     user_id UUID PRIMARY KEY,
     demo_questions TEXT[] DEFAULT ARRAY[]::TEXT[],
     ranker ranker_type NOT NULL DEFAULT 'colpali',
-    vespa_token_id VARCHAR(255),
-    vespa_token_value VARCHAR(255),
     gemini_token VARCHAR(255),
     vespa_cloud_endpoint VARCHAR(255),
     tenant_name VARCHAR(255),

--- a/visual-retrieval-colpali/src/backend/database.py
+++ b/visual-retrieval-colpali/src/backend/database.py
@@ -128,7 +128,7 @@ class Database:
                 save_path.write_bytes(file_content)
 
                 logger.debug(f"Successfully added document {document_name} with ID {new_document.document_id}")
-                return new_document
+                return str(new_document.document_id)
 
         except Exception as e:
             logger.error(f"Error adding document {document_name}: {str(e)}")

--- a/visual-retrieval-colpali/src/backend/database.py
+++ b/visual-retrieval-colpali/src/backend/database.py
@@ -232,9 +232,9 @@ class Database:
             await session.commit()
 
     async def is_application_configured(self, user_id: str) -> bool:
-        documents = await self.get_user_documents(UUID(user_id))
-        has_documents = len(documents) > 0
+        from pathlib import Path
 
+        # Check for settings
         settings = await self.get_user_settings(user_id)
         if not settings:
             return False
@@ -249,7 +249,14 @@ class Database:
 
         has_required_settings = all(setting is not None for setting in required_settings)
 
-        return has_documents and has_required_settings
+        # Check for API key file
+        user_key_dir = Path("storage/user_keys") / str(user_id)
+        uploaded_api_key = False
+        if user_key_dir.exists():
+            pem_files = list(user_key_dir.glob("*.pem"))
+            uploaded_api_key = len(pem_files) > 0
+
+        return has_required_settings and uploaded_api_key
 
     @staticmethod
     def get_default_prompt() -> str:

--- a/visual-retrieval-colpali/src/backend/database.py
+++ b/visual-retrieval-colpali/src/backend/database.py
@@ -1,7 +1,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker as sessionMaker
 from sqlalchemy.schema import CreateTable
-from sqlalchemy import select, delete, and_, true
+from sqlalchemy import select, delete
 from uuid import UUID
 import os
 from typing import Optional, AsyncGenerator
@@ -12,7 +12,6 @@ import logging
 from pathlib import Path
 import torch
 from .auth import hash_password
-import bcrypt
 
 DATABASE_URL = (
     f"postgresql+asyncpg://"
@@ -32,6 +31,7 @@ STORAGE_DIR = Path("storage/user_documents")
 class Database:
     def __init__(self):
         self.session_maker = async_session
+        self.logger = logging.getLogger("vespa_app")
 
     @asynccontextmanager
     async def get_session(self) -> AsyncGenerator[AsyncSession, None]:
@@ -73,14 +73,13 @@ class Database:
 
     async def get_user_documents(self, user_id: UUID):
         """Get all documents for a user"""
-        logger = logging.getLogger("vespa_app")
-        logger.debug(f"Database: Fetching documents for user_id: {user_id}")
+        self.logger.debug(f"Database: Fetching documents for user_id: {user_id}")
         async with self.get_session() as session:
             result = await session.execute(
                 select(UserDocument).where(UserDocument.user_id == user_id)
             )
             documents = result.scalars().all()
-            logger.debug(f"Database: Found {len(documents)} documents")
+            self.logger.debug(f"Database: Found {len(documents)} documents")
             return documents
 
     async def get_user_document_by_id(self, document_id: str):
@@ -93,8 +92,7 @@ class Database:
 
     async def add_user_document(self, user_id: str, document_name: str, file_content: bytes):
         """Add a new document to both filesystem and database"""
-        logger = logging.getLogger("vespa_app")
-        logger.debug(f"Adding document {document_name} for user {user_id}")
+        self.logger.debug(f"Adding document {document_name} for user {user_id}")
 
         try:
             file_ext = Path(document_name).suffix.lower()
@@ -129,11 +127,11 @@ class Database:
                 save_path = user_dir / f"{new_document.document_id}{file_ext}"
                 save_path.write_bytes(file_content)
 
-                logger.debug(f"Successfully added document {document_name} with ID {new_document.document_id}")
+                self.logger.debug(f"Successfully added document {document_name} with ID {new_document.document_id}")
                 return str(new_document.document_id)
 
         except Exception as e:
-            logger.error(f"Error adding document {document_name}: {str(e)}")
+            self.logger.error(f"Error adding document {document_name}: {str(e)}")
             if 'new_document' in locals():
                 async with self.get_session() as session:
                     result = await session.execute(
@@ -146,8 +144,7 @@ class Database:
 
     async def delete_document(self, document_id: str):
         """Delete a document from both database and filesystem"""
-        logger = logging.getLogger("vespa_app")
-        logger.debug(f"Deleting document {document_id}")
+        self.logger.debug(f"Deleting document {document_id}")
 
         try:
             async with self.get_session() as session:
@@ -157,22 +154,22 @@ class Database:
                 document = result.scalar_one_or_none()
 
                 if not document:
-                    logger.warning(f"Document {document_id} not found in database")
+                    self.logger.warning(f"Document {document_id} not found in database")
                     return
 
                 file_path = STORAGE_DIR / str(document.user_id) / f"{document_id}{document.file_extension}"
                 if file_path.exists():
                     file_path.unlink()
-                    logger.info(f"Deleted file {file_path}")
+                    self.logger.info(f"Deleted file {file_path}")
 
                 await session.execute(
                     delete(UserDocument).where(UserDocument.document_id == document_id)
                 )
                 await session.commit()
-                logger.info(f"Deleted database entry for document {document_id}")
+                self.logger.info(f"Deleted database entry for document {document_id}")
 
         except Exception as e:
-            logger.error(f"Error deleting document {document_id}: {str(e)}")
+            self.logger.error(f"Error deleting document {document_id}: {str(e)}")
             raise
 
     async def get_demo_questions(self, user_id: str) -> list[str]:
@@ -237,60 +234,55 @@ class Database:
         """Get all users from the app_user table"""
         async with self.get_session() as session:
             result = await session.execute(
-                select(User) 
+                select(User)
             )
             users = result.scalars().all()
             return [
                 {"user_id": str(user.user_id), "username": user.username, "password": user.password_hash}
                 for user in users
             ]
-       
+
     async def delete_users(self, user_ids: set) -> None:
         """Delete users and their associated data."""
-        logger = logging.getLogger("vespa_app")
         async with self.get_session() as session:
             for user_id in user_ids:
                 user_id_uuid = UUID(user_id)
                 try:
                     await session.execute(delete(UserSettings).where(UserSettings.user_id == user_id_uuid))
-                    logger.info(f"Deleted settings for user ID: {user_id}")
+                    self.logger.debug(f"Deleted settings for user ID: {user_id}")
                     await session.execute(delete(UserDocument).where(UserDocument.user_id == user_id_uuid))
-                    logger.info(f"Deleted documents for user ID: {user_id}")
+                    self.logger.debug(f"Deleted documents for user ID: {user_id}")
 
                     await session.execute(delete(User).where(User.user_id == user_id_uuid))
-                    logger.info(f"Deleted user with ID: {user_id}")
+                    self.logger.info(f"Deleted user with ID: {user_id}")
                 except Exception as e:
-                    logger.error(f"Error deleting user {user_id}: {e}")
+                    self.logger.error(f"Error deleting user {user_id}: {e}")
 
 
     async def create_users(self, users: dict, existing_usernames: set) -> None:
         """Create new users based on input data."""
-        logger = logging.getLogger("vespa_app")
-
         async with self.get_session() as session:
             for user_data in users.values():
                 username = user_data.get("username")
                 password = user_data.get("password")
 
                 if not username or not password:
-                    logger.warning(f"Invalid data for user {username}, skipping.")
+                    self.logger.warning(f"Invalid data for user {username}, skipping.")
                     continue
 
                 if username in existing_usernames:
-                    logger.info(f"Username {username} already exists, skipping.")
+                    self.logger.info(f"Username {username} already exists, skipping.")
                     continue
 
                 try:
                     new_user = User(username=username, password_hash=hash_password(password))
                     session.add(new_user)
-                    logger.info(f"Created user: {username}")
+                    self.logger.info(f"Created user: {username}")
                 except Exception as e:
-                    logger.error(f"Error creating user {username}: {e}")
+                    self.logger.error(f"Error creating user {username}: {e}")
 
     async def update_users(self, users_data: dict) -> None:
         """Update users by deleting and creating as necessary."""
-        logger = logging.getLogger("vespa_app")
-
         users = {
             key.split("_")[1]: {
                 "username": users_data.get(f"username_{key.split('_')[1]}"),
@@ -316,9 +308,9 @@ class Database:
 
             try:
                 await session.commit()
-                logger.info("Users updated successfully")
+                self.logger.info("Users updated successfully")
             except Exception as e:
-                logger.error(f"Error committing user updates: {e}")
+                self.logger.error(f"Error committing user updates: {e}")
                 raise
 
     async def is_application_configured(self, user_id: str) -> bool:
@@ -827,9 +819,6 @@ Only return JSON. Don't return any extra explanation text."""
 }"""
 
     async def store_image_query(self, query_id: str, embeddings: torch.Tensor, text: str, is_visual_only: bool) -> str:
-        logger = logging.getLogger("vespa_app")
-        logger.debug(f"Storing image query with ID {query_id}")
-
         try:
             # Convert embeddings tensor to numpy array and then to list
             embeddings_list = embeddings.detach().cpu().numpy().tolist()
@@ -844,11 +833,11 @@ Only return JSON. Don't return any extra explanation text."""
                 )
                 session.add(image_query)
                 await session.commit()
-                logger.debug(f"Successfully stored image query with ID {query_id}")
+                self.logger.debug(f"Successfully stored image query with ID {query_id}")
                 return query_id
 
         except Exception as e:
-            logger.error(f"Error storing image query: {str(e)}")
+            self.logger.error(f"Error storing image query: {str(e)}")
             raise
 
     async def get_image_query(self, query_id: str) -> Optional[ImageQuery]:

--- a/visual-retrieval-colpali/src/backend/database.py
+++ b/visual-retrieval-colpali/src/backend/database.py
@@ -240,8 +240,6 @@ class Database:
             return False
 
         required_settings = [
-            settings.vespa_token_id,
-            settings.vespa_token_value,
             settings.gemini_token,
             settings.tenant_name,
             settings.app_name,

--- a/visual-retrieval-colpali/src/backend/deploy.py
+++ b/visual-retrieval-colpali/src/backend/deploy.py
@@ -1,11 +1,7 @@
 import os
-import json
-import hashlib
-import torch
-import numpy as np
 from dotenv import load_dotenv
 import logging
-from pydantic import BaseModel
+
 from vespa.package import (
     ApplicationPackage,
     AuthClient,
@@ -26,30 +22,12 @@ from vespa.configuration.services import (
     documents,
     node,
     certificate,
-    token,
     document,
     nodes,
 )
 from vespa.configuration.vt import vt
 from vespa.package import ServicesConfiguration
 from backend.models import UserSettings
-
-# Google Generative AI
-import google.generativeai as genai
-
-# Torch and other ML libraries
-import torch
-from torch.utils.data import DataLoader
-from tqdm import tqdm
-from pdf2image import convert_from_path
-from pypdf import PdfReader
-
-# ColPali model and processor
-from colpali_engine.models import ColPali, ColPaliProcessor
-from vidore_benchmark.utils.image_utils import scale_image, get_base64_image
-
-from PIL import Image
-import pytesseract
 
 import pty
 import subprocess
@@ -67,8 +45,6 @@ async def deploy_application_step_1(settings: UserSettings):
         settings.tenant_name,
         settings.app_name,
         settings.instance_name,
-        settings.vespa_token_id,
-        settings.vespa_token_value,
         settings.gemini_token
     ]):
         raise ValueError("Missing required settings")
@@ -82,8 +58,6 @@ async def deploy_application_step_1(settings: UserSettings):
     base_dir = os.path.dirname(os.path.abspath(__file__))
     parent_dir = os.path.dirname(os.path.dirname(base_dir))
     app_dir = os.path.join(parent_dir, "application")
-
-    copy_api_key_file(app_dir, VESPA_TENANT_NAME)
 
     current_dir = os.getcwd()
 
@@ -196,7 +170,7 @@ async def deploy_application_step_1(settings: UserSettings):
     finally:
         os.chdir(current_dir)
 
-async def deploy_application_step_2(request, settings: UserSettings, user_id: str, model: ColPali, processor: ColPaliProcessor, docNames: dict[str, str]):
+async def deploy_application_step_2(request, settings: UserSettings, user_id: str):
     """Deploy the Vespa application"""
     # Load environment variables
     load_dotenv()
@@ -205,14 +179,12 @@ async def deploy_application_step_2(request, settings: UserSettings, user_id: st
     VESPA_TENANT_NAME = settings.tenant_name
     VESPA_APPLICATION_NAME = settings.app_name
     VESPA_INSTANCE_NAME = settings.instance_name
-    VESPA_SCHEMA_NAME = "pdf_page"
-    VESPA_TOKEN_ID_WRITE = settings.vespa_token_id
-    GEMINI_API_KEY = settings.gemini_token
 
     base_dir = os.path.dirname(os.path.abspath(__file__))
     parent_dir = os.path.dirname(os.path.dirname(base_dir))
-    storage_dir = os.path.join(parent_dir, "src/storage/user_documents", user_id)
     app_dir = os.path.join(parent_dir, "application")
+
+    copy_api_key_file(parent_dir, VESPA_TENANT_NAME)
 
     try:
         logger.debug("Generating services.xml")
@@ -228,11 +200,6 @@ async def deploy_application_step_2(request, settings: UserSettings, user_id: st
                         client(
                             certificate(file="security/clients.pem"),
                             id="mtls",
-                            permissions="read,write",
-                        ),
-                        client(
-                            token(id=f"{VESPA_TOKEN_ID_WRITE}"),
-                            id="token_write",
                             permissions="read,write",
                         ),
                     ),
@@ -344,276 +311,18 @@ async def deploy_application_step_2(request, settings: UserSettings, user_id: st
             # Always restore the original working directory
             os.chdir(current_dir)
 
-        # Configure Google Generative AI
-        genai.configure(api_key=GEMINI_API_KEY)
-
-        logger.info(f"Looking for documents in: {storage_dir}")
-
-        if not os.path.exists(storage_dir):
-            raise FileNotFoundError(f"Directory not found: {storage_dir}")
-
-        pdfPaths = [
-            os.path.join(storage_dir, f)
-            for f in os.listdir(storage_dir)
-            if f.endswith(".pdf")
-        ]
-
-        imgPaths = [
-            os.path.join(storage_dir, f)
-            for f in os.listdir(storage_dir)
-            if f.endswith(".png") or f.endswith(".jpg") or f.endswith(".jpeg")
-        ]
-
-        if not pdfPaths and not imgPaths:
-            raise FileNotFoundError(f"No PDF or image files found in {storage_dir}")
-
-        logger.info(f"Found {len(pdfPaths)} PDF files and {len(imgPaths)} image files to process")
-
-        pdf_pages = []
-
-        # Process PDFs
-        for pdf_file in pdfPaths:
-            logger.debug(f"Processing PDF: {os.path.basename(pdf_file)}")
-            images, texts = get_pdf_images(pdf_file)
-            logger.debug(f"Extracted {len(images)} pages from {os.path.basename(pdf_file)}")
-            for page_no, (image, text) in enumerate(zip(images, texts)):
-                doc_id = os.path.splitext(os.path.basename(pdf_file))[0]
-                title = docNames.get(doc_id, "")
-                static_path = f"/storage/user_documents/{user_id}/{os.path.basename(pdf_file)}"
-                pdf_pages.append(
-                    {
-                        "title": title,
-                        "path": pdf_file,
-                        "url": static_path,
-                        "image": image,
-                        "text": text,
-                        "page_no": page_no,
-                    }
-                )
-
-        # Process Images
-        for img_file in imgPaths:
-            logger.debug(f"Processing image: {os.path.basename(img_file)}")
-            images, texts = get_image_with_text(img_file)
-            logger.debug(f"Extracted text from {os.path.basename(img_file)}")
-            for page_no, (image, text) in enumerate(zip(images, texts)):
-                doc_id = os.path.splitext(os.path.basename(img_file))[0]
-                title = docNames.get(doc_id, "")
-                static_path = f"/storage/user_documents/{user_id}/{os.path.basename(img_file)}"
-                pdf_pages.append(
-                    {
-                        "title": title,
-                        "path": img_file,
-                        "url": static_path,
-                        "image": image,
-                        "text": text,
-                        "page_no": page_no,
-                    }
-                )
-
-        logger.info(f"Total processed: {len(pdf_pages)} pages")
-
-        prompt_text, pydantic_model = settings.prompt, GeneratedQueries
-
-        logger.debug(f"Generating queries")
-
-        for pdf in tqdm(pdf_pages):
-            image = pdf.get("image")
-            pdf["queries"] = generate_queries(image, prompt_text, pydantic_model)
-
-        images = [pdf["image"] for pdf in pdf_pages]
-        embeddings = generate_embeddings(images, model, processor)
-
-        logger.info(f"Generated {len(embeddings)} embeddings")
-
-        vespa_feed = []
-        for pdf, embedding in zip(pdf_pages, embeddings):
-            title = pdf["title"]
-            image = pdf["image"]
-            url = pdf["url"]
-            text = pdf.get("text", "")
-            page_no = pdf["page_no"]
-            query_dict = pdf["queries"]
-            questions = [v for k, v in query_dict.items() if "question" in k and v]
-            queries = [v for k, v in query_dict.items() if "query" in k and v]
-            base_64_image = get_base64_image(
-                scale_image(image, 32), add_url_prefix=False
-            )  # Scaled down image to return fast on search (~1kb)
-            base_64_full_image = get_base64_image(image, add_url_prefix=False)
-            embedding_dict = {k: v for k, v in enumerate(embedding)}
-            binary_embedding = float_to_binary_embedding(embedding_dict)
-            # id_hash should be md5 hash of url and page_number
-            id_hash = hashlib.md5(f"{title}_{page_no}".encode()).hexdigest()
-            page = {
-                "id": id_hash,
-                "fields": {
-                    "id": id_hash,
-                    "title": title,
-                    "url": url,
-                    "page_number": page_no,
-                    "blur_image": base_64_image,
-                    "full_image": base_64_full_image,
-                    "text": text,
-                    "embedding": binary_embedding,
-                    "queries": queries,
-                    "questions": questions,
-                },
-            }
-            vespa_feed.append(page)
-
-        with open(app_dir + "/vespa_feed.json", "w") as f:
-            vespa_feed_to_save = []
-            for page in vespa_feed:
-                document_id = page["id"]
-                put_id = f"id:{VESPA_APPLICATION_NAME}:{VESPA_SCHEMA_NAME}::{document_id}"
-                vespa_feed_to_save.append({"put": put_id, "fields": page["fields"]})
-            json.dump(vespa_feed_to_save, f)
-
-        logger.debug(f"Saved vespa feed to {app_dir}/vespa_feed.json")
-
-        current_dir = os.getcwd()
-
-        try:
-            logger.debug("Feeding vespa application")
-
-            # Change to application directory
-            os.chdir(app_dir)
-
-            subprocess.run(["vespa", "feed", "vespa_feed.json", "-a", f"{VESPA_TENANT_NAME}.{VESPA_APPLICATION_NAME}.{VESPA_INSTANCE_NAME}"], check=True)
-
-            logger.info(f"Feeding completed successfully!")
-        finally:
-            # Always restore the original working directory
-            os.chdir(current_dir)
-
         return {"status": "success"}
 
     except Exception as e:
         logger.error(f"Deployment failed: {str(e)}")
         raise
 
-def get_pdf_images(pdf_path):
-    reader = PdfReader(pdf_path)
-    page_texts = []
-    for page_number in range(len(reader.pages)):
-        page = reader.pages[page_number]
-        text = page.extract_text()
-        page_texts.append(text)
-    images = convert_from_path(pdf_path)
-    # Convert to PIL images
-    assert len(images) == len(page_texts)
-    return images, page_texts
-
-def get_image_with_text(image_path):
-    """Process a single image file and extract its text using OCR"""
-    try:
-        # Open and process image
-        image = Image.open(image_path)
-
-        # Extract text using OCR
-        text = pytesseract.image_to_string(image)
-
-        # Return tuple of image and text (similar to get_pdf_images format)
-        return [image], [text]
-    except Exception as e:
-        logger.error(f"Error processing image {image_path}: {str(e)}")
-        raise
-
-class GeneratedQueries(BaseModel):
-    broad_topical_question: str
-    broad_topical_query: str
-    specific_detail_question: str
-    specific_detail_query: str
-    visual_element_question: str
-    visual_element_query: str
-
-def generate_queries(image, prompt_text, pydantic_model):
-    gemini_model = genai.GenerativeModel("gemini-1.5-flash-8b")
-
-    try:
-        response = gemini_model.generate_content(
-            [image, "\n\n", prompt_text],
-            generation_config=genai.GenerationConfig(
-                response_mime_type="application/json",
-                response_schema=pydantic_model,
-            ),
-        )
-        queries = json.loads(response.text)
-    except Exception as _e:
-        queries = {
-            "broad_topical_question": "",
-            "broad_topical_query": "",
-            "specific_detail_question": "",
-            "specific_detail_query": "",
-            "visual_element_question": "",
-            "visual_element_query": "",
-        }
-    return queries
-
-def generate_embeddings(images, model, processor, batch_size=1) -> np.ndarray:
-    """
-    Generate embeddings for a list of images.
-    Move to CPU only once per batch.
-
-    Args:
-        images (List[PIL.Image]): List of PIL images.
-        model (nn.Module): The model to generate embeddings.
-        processor: The processor to preprocess images.
-        batch_size (int, optional): Batch size for processing. Defaults to 64.
-
-    Returns:
-        np.ndarray: Embeddings for the images, shape
-                    (len(images), processor.max_patch_length (1030 for ColPali), model.config.hidden_size (Patch embedding dimension - 128 for ColPali)).
-    """
-
-    def collate_fn(batch):
-        # Batch is a list of images
-        return processor.process_images(batch)  # Should return a dict of tensors
-
-    dataloader = DataLoader(
-        images,
-        shuffle=False,
-        collate_fn=collate_fn,
-    )
-
-    embeddings_list = []
-    for batch in tqdm(dataloader):
-        with torch.no_grad():
-            batch = {k: v.to(model.device) for k, v in batch.items()}
-            embeddings_batch = model(**batch)
-            # Convert tensor to numpy array and append to list
-            embeddings_list.extend(
-                [t.cpu().numpy() for t in torch.unbind(embeddings_batch)]
-            )
-
-    # Stack all embeddings into a single numpy array
-    all_embeddings = np.stack(embeddings_list, axis=0)
-    return all_embeddings
-
-def float_to_binary_embedding(float_query_embedding: dict) -> dict:
-    """Utility function to convert float query embeddings to binary query embeddings."""
-    binary_query_embeddings = {}
-    for k, v in float_query_embedding.items():
-        binary_vector = (
-            np.packbits(np.where(np.array(v) > 0, 1, 0)).astype(np.int8).tolist()
-        )
-        binary_query_embeddings[k] = binary_vector
-    return binary_query_embeddings
-
-# A function to create an inherited rank profile which also returns quantized similarity scores
-def with_quantized_similarity(rank_profile: RankProfile) -> RankProfile:
-    return RankProfile(
-        name=f"{rank_profile.name}_sim",
-        first_phase=rank_profile.first_phase,
-        inherits=rank_profile.name,
-        summary_features=["quantized"],
-    )
-
-def copy_api_key_file(app_dir, tenant_name):
-    # Find any .pem file in the source directory
-    api_key_src = next((f for f in os.listdir(app_dir) if f.endswith('.pem')), None)
+def copy_api_key_file(parent_dir, tenant_name):
+    storage_dir = os.path.join(parent_dir, "application")
+    # Find any .pem file in the given directory
+    api_key_src = next((f for f in os.listdir(storage_dir) if f.endswith('.pem')), None)
     if api_key_src:
-        api_key_src = os.path.join(app_dir, api_key_src)
+        api_key_src = os.path.join(storage_dir, api_key_src)
     else:
         raise FileNotFoundError("No .pem file found in application directory")
 

--- a/visual-retrieval-colpali/src/backend/feed.py
+++ b/visual-retrieval-colpali/src/backend/feed.py
@@ -1,0 +1,287 @@
+import os
+import json
+import hashlib
+import subprocess
+import logging
+import numpy as np
+from tqdm import tqdm
+from backend.models import UserSettings
+from pydantic import BaseModel
+import google.generativeai as genai
+import torch
+from torch.utils.data import DataLoader
+
+from pdf2image import convert_from_path
+from pypdf import PdfReader
+from PIL import Image
+import pytesseract
+
+# ColPali model and processor
+from colpali_engine.models import ColPali, ColPaliProcessor
+from vidore_benchmark.utils.image_utils import scale_image, get_base64_image
+
+logger = logging.getLogger("vespa_app")
+
+
+
+def feed_documents_to_vespa(settings: UserSettings, user_id: str, model: ColPali, processor: ColPaliProcessor, docNames: dict[str, str]):
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    parent_dir = os.path.dirname(os.path.dirname(base_dir))
+    storage_dir = os.path.join(parent_dir, "src/storage/user_documents", user_id)
+    app_dir = os.path.join(parent_dir, "application")
+
+    VESPA_TENANT_NAME = settings.tenant_name
+    VESPA_APPLICATION_NAME = settings.app_name
+    VESPA_INSTANCE_NAME = settings.instance_name
+    VESPA_SCHEMA_NAME = "pdf_page"
+    GEMINI_API_KEY = settings.gemini_token
+
+    # Configure Google Generative AI
+    genai.configure(api_key=GEMINI_API_KEY)
+
+    logger.info(f"Looking for documents in: {storage_dir}")
+
+    if not os.path.exists(storage_dir):
+        raise FileNotFoundError(f"Directory not found: {storage_dir}")
+
+    pdfPaths = [
+        os.path.join(storage_dir, f)
+        for f in os.listdir(storage_dir)
+        if f.endswith(".pdf")
+    ]
+
+    imgPaths = [
+        os.path.join(storage_dir, f)
+        for f in os.listdir(storage_dir)
+        if f.endswith(".png") or f.endswith(".jpg") or f.endswith(".jpeg")
+    ]
+
+    if not pdfPaths and not imgPaths:
+        raise FileNotFoundError(f"No PDF or image files found in {storage_dir}")
+
+    logger.info(f"Found {len(pdfPaths)} PDF files and {len(imgPaths)} image files to process")
+
+    pdf_pages = []
+
+    # Process PDFs
+    for pdf_file in pdfPaths:
+        logger.debug(f"Processing PDF: {os.path.basename(pdf_file)}")
+        images, texts = get_pdf_images(pdf_file)
+        logger.debug(f"Extracted {len(images)} pages from {os.path.basename(pdf_file)}")
+        for page_no, (image, text) in enumerate(zip(images, texts)):
+            doc_id = os.path.splitext(os.path.basename(pdf_file))[0]
+            title = docNames.get(doc_id, "")
+            static_path = f"/storage/user_documents/{user_id}/{os.path.basename(pdf_file)}"
+            pdf_pages.append(
+                {
+                    "title": title,
+                    "path": pdf_file,
+                    "url": static_path,
+                    "image": image,
+                    "text": text,
+                    "page_no": page_no,
+                }
+            )
+
+    # Process Images
+    for img_file in imgPaths:
+        logger.debug(f"Processing image: {os.path.basename(img_file)}")
+        images, texts = get_image_with_text(img_file)
+        logger.debug(f"Extracted text from {os.path.basename(img_file)}")
+        for page_no, (image, text) in enumerate(zip(images, texts)):
+            doc_id = os.path.splitext(os.path.basename(img_file))[0]
+            title = docNames.get(doc_id, "")
+            static_path = f"/storage/user_documents/{user_id}/{os.path.basename(img_file)}"
+            pdf_pages.append(
+                {
+                    "title": title,
+                    "path": img_file,
+                    "url": static_path,
+                    "image": image,
+                    "text": text,
+                    "page_no": page_no,
+                }
+            )
+
+    logger.info(f"Total processed: {len(pdf_pages)} pages")
+
+    prompt_text, pydantic_model = settings.prompt, GeneratedQueries
+
+    logger.debug(f"Generating queries")
+
+    for pdf in tqdm(pdf_pages):
+        image = pdf.get("image")
+        pdf["queries"] = generate_queries(image, prompt_text, pydantic_model)
+
+    images = [pdf["image"] for pdf in pdf_pages]
+    embeddings = generate_embeddings(images, model, processor)
+
+    logger.info(f"Generated {len(embeddings)} embeddings")
+
+    vespa_feed = []
+    for pdf, embedding in zip(pdf_pages, embeddings):
+        title = pdf["title"]
+        image = pdf["image"]
+        url = pdf["url"]
+        text = pdf.get("text", "")
+        page_no = pdf["page_no"]
+        query_dict = pdf["queries"]
+        questions = [v for k, v in query_dict.items() if "question" in k and v]
+        queries = [v for k, v in query_dict.items() if "query" in k and v]
+        base_64_image = get_base64_image(
+            scale_image(image, 32), add_url_prefix=False
+        )  # Scaled down image to return fast on search (~1kb)
+        base_64_full_image = get_base64_image(image, add_url_prefix=False)
+        embedding_dict = {k: v for k, v in enumerate(embedding)}
+        binary_embedding = float_to_binary_embedding(embedding_dict)
+        # id_hash should be md5 hash of url and page_number
+        id_hash = hashlib.md5(f"{title}_{page_no}".encode()).hexdigest()
+        page = {
+            "id": id_hash,
+            "fields": {
+                "id": id_hash,
+                "title": title,
+                "url": url,
+                "page_number": page_no,
+                "blur_image": base_64_image,
+                "full_image": base_64_full_image,
+                "text": text,
+                "embedding": binary_embedding,
+                "queries": queries,
+                "questions": questions,
+            },
+        }
+        vespa_feed.append(page)
+
+    with open(app_dir + "/vespa_feed.json", "w") as f:
+        vespa_feed_to_save = []
+        for page in vespa_feed:
+            document_id = page["id"]
+            put_id = f"id:{VESPA_APPLICATION_NAME}:{VESPA_SCHEMA_NAME}::{document_id}"
+            vespa_feed_to_save.append({"put": put_id, "fields": page["fields"]})
+        json.dump(vespa_feed_to_save, f)
+
+    logger.debug(f"Saved vespa feed to {app_dir}/vespa_feed.json")
+
+    current_dir = os.getcwd()
+
+    try:
+        logger.debug("Feeding vespa application")
+
+        # Change to application directory
+        os.chdir(app_dir)
+
+        subprocess.run(["vespa", "feed", "vespa_feed.json", "-a", f"{VESPA_TENANT_NAME}.{VESPA_APPLICATION_NAME}.{VESPA_INSTANCE_NAME}"], check=True)
+
+        logger.info(f"Feeding completed successfully!")
+    finally:
+        # Always restore the original working directory
+        os.chdir(current_dir)
+
+def get_pdf_images(pdf_path):
+    reader = PdfReader(pdf_path)
+    page_texts = []
+    for page_number in range(len(reader.pages)):
+        page = reader.pages[page_number]
+        text = page.extract_text()
+        page_texts.append(text)
+    images = convert_from_path(pdf_path)
+    # Convert to PIL images
+    assert len(images) == len(page_texts)
+    return images, page_texts
+
+def float_to_binary_embedding(float_query_embedding: dict) -> dict:
+    """Utility function to convert float query embeddings to binary query embeddings."""
+    binary_query_embeddings = {}
+    for k, v in float_query_embedding.items():
+        binary_vector = (
+            np.packbits(np.where(np.array(v) > 0, 1, 0)).astype(np.int8).tolist()
+        )
+        binary_query_embeddings[k] = binary_vector
+    return binary_query_embeddings
+
+def get_image_with_text(image_path):
+    """Process a single image file and extract its text using OCR"""
+    try:
+        # Open and process image
+        image = Image.open(image_path)
+
+        # Extract text using OCR
+        text = pytesseract.image_to_string(image)
+
+        # Return tuple of image and text (similar to get_pdf_images format)
+        return [image], [text]
+    except Exception as e:
+        logger.error(f"Error processing image {image_path}: {str(e)}")
+        raise
+
+class GeneratedQueries(BaseModel):
+    broad_topical_question: str
+    broad_topical_query: str
+    specific_detail_question: str
+    specific_detail_query: str
+    visual_element_question: str
+    visual_element_query: str
+
+def generate_queries(image, prompt_text, pydantic_model):
+    gemini_model = genai.GenerativeModel("gemini-1.5-flash-8b")
+
+    try:
+        response = gemini_model.generate_content(
+            [image, "\n\n", prompt_text],
+            generation_config=genai.GenerationConfig(
+                response_mime_type="application/json",
+                response_schema=pydantic_model,
+            ),
+        )
+        queries = json.loads(response.text)
+    except Exception as _e:
+        queries = {
+            "broad_topical_question": "",
+            "broad_topical_query": "",
+            "specific_detail_question": "",
+            "specific_detail_query": "",
+            "visual_element_question": "",
+            "visual_element_query": "",
+        }
+    return queries
+
+def generate_embeddings(images, model, processor, batch_size=1) -> np.ndarray:
+    """
+    Generate embeddings for a list of images.
+    Move to CPU only once per batch.
+
+    Args:
+        images (List[PIL.Image]): List of PIL images.
+        model (nn.Module): The model to generate embeddings.
+        processor: The processor to preprocess images.
+        batch_size (int, optional): Batch size for processing. Defaults to 64.
+
+    Returns:
+        np.ndarray: Embeddings for the images, shape
+                    (len(images), processor.max_patch_length (1030 for ColPali), model.config.hidden_size (Patch embedding dimension - 128 for ColPali)).
+    """
+
+    def collate_fn(batch):
+        # Batch is a list of images
+        return processor.process_images(batch)  # Should return a dict of tensors
+
+    dataloader = DataLoader(
+        images,
+        shuffle=False,
+        collate_fn=collate_fn,
+    )
+
+    embeddings_list = []
+    for batch in tqdm(dataloader):
+        with torch.no_grad():
+            batch = {k: v.to(model.device) for k, v in batch.items()}
+            embeddings_batch = model(**batch)
+            # Convert tensor to numpy array and append to list
+            embeddings_list.extend(
+                [t.cpu().numpy() for t in torch.unbind(embeddings_batch)]
+            )
+
+    # Stack all embeddings into a single numpy array
+    all_embeddings = np.stack(embeddings_list, axis=0)
+    return all_embeddings

--- a/visual-retrieval-colpali/src/backend/models.py
+++ b/visual-retrieval-colpali/src/backend/models.py
@@ -40,8 +40,6 @@ class UserSettings(Base):
         nullable=False,
         default=RankerType.colpali
     )
-    vespa_token_id = Column(String, nullable=True)
-    vespa_token_value = Column(String, nullable=True)
     gemini_token = Column(String, nullable=True)
     vespa_cloud_endpoint = Column(String, nullable=True)
     tenant_name = Column(String, nullable=True)

--- a/visual-retrieval-colpali/src/frontend/components/my_documents.py
+++ b/visual-retrieval-colpali/src/frontend/components/my_documents.py
@@ -1,4 +1,4 @@
-from fasthtml.common import Button, Div, H1, Form, Input, P
+from fasthtml.common import Button, Div, H1, Form, Input, P, H2
 from shad4fast import (
     Table,
     TableBody,
@@ -10,8 +10,9 @@ from shad4fast import (
 from lucide_fasthtml import Lucide
 
 class MyDocuments:
-    def __init__(self, documents=None):
+    def __init__(self, documents=None, app_deployed=False):
         self.documents = documents
+        self.app_deployed = app_deployed
 
     def documents_table(self):
         def get_file_icon(file_extension: str) -> str:
@@ -88,8 +89,7 @@ class MyDocuments:
                         id="file-input",
                         hx_trigger="change",
                         hx_post="/upload-files",
-                        hx_encoding="multipart/form-data",
-                        hx_target="#documents-list",
+                        hx_encoding="multipart/form-data"
                     ),
                     Div(
                         Button(
@@ -97,6 +97,11 @@ class MyDocuments:
                             type="button",
                             cls="bg-black dark:bg-gray-900 text-white px-6 py-2 rounded-[10px] hover:opacity-80",
                             onclick="document.getElementById('file-input').click()"
+                        ) if self.app_deployed else Button(
+                            "Upload new",
+                            cls="bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 px-6 py-2 rounded-[10px]",
+                            id="deploy-button",
+                            disabled=True,
                         ),
                         Div(
                             Lucide(
@@ -104,8 +109,8 @@ class MyDocuments:
                                 cls="size-5 cursor-pointer ml-6 dark:brightness-0 dark:invert"
                             ),
                             P(
-                                "Supported formats: PDF, PNG, JPG, JPEG. Other formats will be ignored.",
-                                cls="absolute invisible group-hover:visible bg-white dark:bg-gray-900 text-black dark:text-white p-3 rounded-[10px] text-sm -mt-12 ml-2 shadow-sm min-w-[400px]"
+                                "The app must be deployed to upload documents. Supported formats: PDF, PNG, JPG, JPEG. Other formats will be ignored.",
+                                cls="absolute invisible group-hover:visible bg-white dark:bg-gray-900 text-black dark:text-white p-3 rounded-[10px] text-sm -mt-12 ml-2 shadow-sm min-w-[300px] max-w-[300px]"
                             ),
                             cls="relative inline-block group"
                         ),
@@ -121,3 +126,57 @@ class MyDocuments:
                 cls="container mx-auto max-w-4xl p-8"
             )
         )
+
+def DocumentProcessingModal():
+    return Div(
+        Div(
+            Div(
+                H2(
+                    "Processing the uploaded documents",
+                    cls="text-xl font-semibold mb-2 text-gray-900 dark:text-white"
+                ),
+                P(
+                    "Processing documents' information with AI to feed Vespa",
+                    cls="text-gray-500 dark:text-gray-400"
+                ),
+                Div(
+                    Lucide(icon="loader-circle", cls="size-10 animate-spin"),
+                    cls="mt-6 flex justify-center"
+                ),
+                cls="bg-white dark:bg-gray-900 p-8 rounded-[10px] shadow-md max-w-md w-full text-center"
+            ),
+            cls="fixed inset-0 flex items-center justify-center z-50 p-4"
+        ),
+        cls="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm z-40"
+    )
+
+def DocumentProcessingErrorModal(message: str):
+    return Div(
+        Div(
+            Div(
+                Div(
+                    Lucide(icon="circle-x", cls="size-12 text-red-500"),
+                    cls="flex justify-center mb-4"
+                ),
+                H2(
+                    "Document processing failed",
+                    cls="text-xl font-semibold mb-2 text-gray-900 dark:text-white"
+                ),
+                P(
+                    "The document processing failed, check the console logs for more details",
+                    cls="text-gray-500 dark:text-gray-400 mb-6"
+                ) if message is None else P(
+                    message,
+                    cls="text-gray-500 dark:text-gray-400 mb-6"
+                ),
+                Button(
+                    "OK",
+                    cls="w-full p-4 bg-black text-white rounded-[10px] hover:bg-gray-800 transition-colors",
+                    onclick="document.getElementById('document-processing-modal').remove(); window.location.href = '/my-documents';"
+                ),
+                cls="bg-white dark:bg-gray-900 p-8 rounded-[10px] shadow-md max-w-md w-full text-center"
+            ),
+            cls="fixed inset-0 flex items-center justify-center z-50 p-4"
+        ),
+        cls="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm z-40"
+    )

--- a/visual-retrieval-colpali/src/frontend/components/my_documents.py
+++ b/visual-retrieval-colpali/src/frontend/components/my_documents.py
@@ -109,7 +109,7 @@ class MyDocuments:
                                 cls="size-5 cursor-pointer ml-6 dark:brightness-0 dark:invert"
                             ),
                             P(
-                                "The app must be deployed to upload documents. Supported formats: PDF, PNG, JPG, JPEG. Other formats will be ignored.",
+                                "The app must be deployed to upload documents.\nSupported formats: PDF, PNG, JPG, JPEG.\nOther formats will be ignored.",
                                 cls="absolute invisible group-hover:visible bg-white dark:bg-gray-900 text-black dark:text-white p-3 rounded-[10px] text-sm -mt-12 ml-2 shadow-sm min-w-[300px] max-w-[300px]"
                             ),
                             cls="relative inline-block group"

--- a/visual-retrieval-colpali/src/frontend/components/my_documents.py
+++ b/visual-retrieval-colpali/src/frontend/components/my_documents.py
@@ -61,7 +61,8 @@ class MyDocuments:
                             Button(
                                 Lucide("trash-2", cls="dark:brightness-0 dark:invert", size='20'),
                                 type="button",
-                                cls="hover:opacity-80",
+                                disabled=not self.app_deployed,
+                                cls="hover:opacity-80 cursor-pointer" if self.app_deployed else "opacity-50 cursor-not-allowed",
                                 hx_delete=f"/delete-document/{doc.document_id}",
                                 hx_target="#documents-list",
                                 hx_confirm=f"Are you sure you want to delete {doc.document_name}?"
@@ -109,7 +110,7 @@ class MyDocuments:
                                 cls="size-5 cursor-pointer ml-6 dark:brightness-0 dark:invert"
                             ),
                             P(
-                                "The app must be deployed to upload documents.\nSupported formats: PDF, PNG, JPG, JPEG.\nOther formats will be ignored.",
+                                "The app must be deployed to upload or delete documents.\nSupported formats: PDF, PNG, JPG, JPEG.\nOther formats will be ignored.",
                                 cls="absolute invisible group-hover:visible bg-white dark:bg-gray-900 text-black dark:text-white p-3 rounded-[10px] text-sm -mt-12 ml-2 shadow-sm min-w-[300px] max-w-[300px]"
                             ),
                             cls="relative inline-block group"
@@ -136,7 +137,7 @@ def DocumentProcessingModal():
                     cls="text-xl font-semibold mb-2 text-gray-900 dark:text-white"
                 ),
                 P(
-                    "Processing documents' information with AI to feed Vespa",
+                    "The AI is processing your documents and feeding them into Vespa Cloud",
                     cls="text-gray-500 dark:text-gray-400"
                 ),
                 Div(
@@ -173,6 +174,60 @@ def DocumentProcessingErrorModal(message: str):
                     "OK",
                     cls="w-full p-4 bg-black text-white rounded-[10px] hover:bg-gray-800 transition-colors",
                     onclick="document.getElementById('document-processing-modal').remove(); window.location.href = '/my-documents';"
+                ),
+                cls="bg-white dark:bg-gray-900 p-8 rounded-[10px] shadow-md max-w-md w-full text-center"
+            ),
+            cls="fixed inset-0 flex items-center justify-center z-50 p-4"
+        ),
+        cls="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm z-40"
+    )
+
+def DocumentDeletingModal():
+    return Div(
+        Div(
+            Div(
+                H2(
+                    "Deleting document",
+                    cls="text-xl font-semibold mb-2 text-gray-900 dark:text-white"
+                ),
+                P(
+                    "Deleting the document from the database",
+                    cls="text-gray-500 dark:text-gray-400"
+                ),
+                Div(
+                    Lucide(icon="loader-circle", cls="size-10 animate-spin"),
+                    cls="mt-6 flex justify-center"
+                ),
+                cls="bg-white dark:bg-gray-900 p-8 rounded-[10px] shadow-md max-w-md w-full text-center"
+            ),
+            cls="fixed inset-0 flex items-center justify-center z-50 p-4"
+        ),
+        cls="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm z-40"
+    )
+
+def DocumentDeletingErrorModal(message: str):
+    return Div(
+        Div(
+            Div(
+                Div(
+                    Lucide(icon="circle-x", cls="size-12 text-red-500"),
+                    cls="flex justify-center mb-4"
+                ),
+                H2(
+                    "Document deleting failed",
+                    cls="text-xl font-semibold mb-2 text-gray-900 dark:text-white"
+                ),
+                P(
+                    "The document deleting failed, check the console logs for more details",
+                    cls="text-gray-500 dark:text-gray-400 mb-6"
+                ) if message is None else P(
+                    message,
+                    cls="text-gray-500 dark:text-gray-400 mb-6"
+                ),
+                Button(
+                    "OK",
+                    cls="w-full p-4 bg-black text-white rounded-[10px] hover:bg-gray-800 transition-colors",
+                    onclick="document.getElementById('document-deleting-modal').remove(); window.location.href = '/my-documents';"
                 ),
                 cls="bg-white dark:bg-gray-900 p-8 rounded-[10px] shadow-md max-w-md w-full text-center"
             ),

--- a/visual-retrieval-colpali/src/frontend/components/settings.py
+++ b/visual-retrieval-colpali/src/frontend/components/settings.py
@@ -237,36 +237,6 @@ def ConnectionSettings(settings: UserSettings = None):
                         H2("Tokens", cls="text-lg font-semibold mb-4"),
                         Div(
                             Label(
-                                "Vespa.ai token ID ",
-                                Span("*", cls="text-red-500"),
-                                htmlFor="vespa-token-id",
-                                cls="text-sm font-medium"
-                            ),
-                            Input(
-                                value=settings.vespa_token_id if settings else '',
-                                cls="flex-1 w-full rounded-[10px] border border-input bg-background px-3 py-2 text-sm ring-offset-background",
-                                name="vespa_token_id",
-                                required=True
-                            ),
-                            cls="space-y-2 mb-4"
-                        ),
-                        Div(
-                            Label(
-                                "Vespa.ai token value ",
-                                Span("*", cls="text-red-500"),
-                                htmlFor="vespa-token-value",
-                                cls="text-sm font-medium"
-                            ),
-                            Input(
-                                value=settings.vespa_token_value if settings else '',
-                                cls="flex-1 w-full rounded-[10px] border border-input bg-background px-3 py-2 text-sm ring-offset-background",
-                                name="vespa_token_value",
-                                required=True
-                            ),
-                            cls="space-y-2 mb-4"
-                        ),
-                        Div(
-                            Label(
                                 "Gemini API token ",
                                 Span("*", cls="text-red-500"),
                                 htmlFor="gemini-token",

--- a/visual-retrieval-colpali/src/main.py
+++ b/visual-retrieval-colpali/src/main.py
@@ -743,12 +743,7 @@ async def delete_document(request, document_id: str):
             return vespa_result
 
         await app.db.delete_document(document_id)
-        documents = await app.db.get_user_documents(user_id)
-
-        return {
-            "status": "success",
-            "content": str(MyDocuments(documents=documents).documents_table())
-        }
+        return {"status": "success"}
 
     except Exception as e:
         logger.error(f"Error deleting document: {str(e)}")

--- a/visual-retrieval-colpali/src/main.py
+++ b/visual-retrieval-colpali/src/main.py
@@ -799,8 +799,6 @@ async def update_connection_settings(request):
     form = await request.form()
 
     settings = {
-        'vespa_token_id': form.get('vespa_token_id'),
-        'vespa_token_value': form.get('vespa_token_value'),
         'gemini_token': form.get('gemini_token'),
     }
 

--- a/visual-retrieval-colpali/src/main.py
+++ b/visual-retrieval-colpali/src/main.py
@@ -700,6 +700,16 @@ async def delete_document(request, document_id: str):
     user_id = request.session["user_id"]
 
     try:
+        # Get settings for Vespa removal
+        settings = await request.app.db.get_user_settings(user_id)
+        if not settings:
+            logger.error("Settings not found")
+            return {"status": "error", "message": "Settings not found"}
+
+        # First remove from Vespa
+        remove_document_from_vespa(settings, document_id)
+
+        # Then delete from database and filesystem
         await app.db.delete_document(document_id)
 
         # Return updated table

--- a/visual-retrieval-colpali/src/main.py
+++ b/visual-retrieval-colpali/src/main.py
@@ -882,12 +882,7 @@ async def deploy_part_2(request):
             logger.error("Settings not found")
             return {"status": "error", "message": "Settings not found"}
 
-        model = app.sim_map_generator.model
-        processor = app.sim_map_generator.processor
-        documents = await request.app.db.get_user_documents(user_id)
-        doc_names = {doc.document_id: doc.document_name for doc in documents}
-
-        result = await deploy_application_step_2(request, settings, user_id, model, processor, doc_names)
+        result = await deploy_application_step_2(request, settings, user_id)
 
         # Read the settings again to get the new URL
         settings: UserSettings = await request.app.db.get_user_settings(user_id)

--- a/visual-retrieval-colpali/src/output.css
+++ b/visual-retrieval-colpali/src/output.css
@@ -780,6 +780,10 @@ body {
   margin-top: -3rem;
 }
 
+.-mt-16 {
+  margin-top: -4rem;
+}
+
 .mb-1 {
   margin-bottom: 0.25rem;
 }
@@ -955,8 +959,16 @@ body {
   width: 12rem;
 }
 
+.w-\[400px\] {
+  width: 400px;
+}
+
 .w-full {
   width: 100%;
+}
+
+.min-w-\[400px\] {
+  min-width: 400px;
 }
 
 .min-w-\[300px\] {
@@ -965,10 +977,6 @@ body {
 
 .max-w-4xl {
   max-width: 56rem;
-}
-
-.max-w-\[300px\] {
-  max-width: 300px;
 }
 
 .max-w-\[50\%\] {
@@ -985,6 +993,14 @@ body {
 
 .max-w-screen-xl {
   max-width: 1280px;
+}
+
+.max-w-\[400px\] {
+  max-width: 400px;
+}
+
+.max-w-\[300px\] {
+  max-width: 300px;
 }
 
 .flex-1 {
@@ -1190,6 +1206,10 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.whitespace-pre-line {
+  white-space: pre-line;
 }
 
 .break-words {

--- a/visual-retrieval-colpali/src/output.css
+++ b/visual-retrieval-colpali/src/output.css
@@ -780,10 +780,6 @@ body {
   margin-top: -3rem;
 }
 
-.-mt-16 {
-  margin-top: -4rem;
-}
-
 .mb-1 {
   margin-bottom: 0.25rem;
 }
@@ -959,16 +955,8 @@ body {
   width: 12rem;
 }
 
-.w-\[400px\] {
-  width: 400px;
-}
-
 .w-full {
   width: 100%;
-}
-
-.min-w-\[400px\] {
-  min-width: 400px;
 }
 
 .min-w-\[300px\] {
@@ -977,6 +965,10 @@ body {
 
 .max-w-4xl {
   max-width: 56rem;
+}
+
+.max-w-\[300px\] {
+  max-width: 300px;
 }
 
 .max-w-\[50\%\] {
@@ -993,14 +985,6 @@ body {
 
 .max-w-screen-xl {
   max-width: 1280px;
-}
-
-.max-w-\[400px\] {
-  max-width: 400px;
-}
-
-.max-w-\[300px\] {
-  max-width: 300px;
 }
 
 .flex-1 {
@@ -1206,10 +1190,6 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.whitespace-pre-line {
-  white-space: pre-line;
 }
 
 .break-words {

--- a/visual-retrieval-colpali/src/output.css
+++ b/visual-retrieval-colpali/src/output.css
@@ -728,24 +728,24 @@ body {
   left: 0px;
 }
 
-.right-0 {
-  right: 0px;
+.left-1\/2 {
+  left: 50%;
 }
 
-.top-0 {
-  top: 0px;
+.right-0 {
+  right: 0px;
 }
 
 .right-2 {
   right: 0.5rem;
 }
 
-.top-1\/2 {
-  top: 50%;
+.top-0 {
+  top: 0px;
 }
 
-.left-1\/2 {
-  left: 50%;
+.top-1\/2 {
+  top: 50%;
 }
 
 .z-40 {
@@ -754,10 +754,6 @@ body {
 
 .z-50 {
   z-index: 50;
-}
-
-.m-1 {
-  margin: 0.25rem;
 }
 
 .-mx-4 {
@@ -788,6 +784,10 @@ body {
   margin-top: -4rem;
 }
 
+.mb-1 {
+  margin-bottom: 0.25rem;
+}
+
 .mb-2 {
   margin-bottom: 0.5rem;
 }
@@ -806,6 +806,10 @@ body {
 
 .mb-\[16vh\] {
   margin-bottom: 16vh;
+}
+
+.ml-1 {
+  margin-left: 0.25rem;
 }
 
 .ml-2 {
@@ -860,25 +864,6 @@ body {
   margin-top: 8vh;
 }
 
-.mt-28 {
-  margin-top: 7rem;
-}
-
-.ml-1 {
-  margin-left: 0.25rem;
-}
-
-.mb-1 {
-  margin-bottom: 0.25rem;
-}
-
-.line-clamp-3 {
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-}
-
 .block {
   display: block;
 }
@@ -907,10 +892,6 @@ body {
   display: none;
 }
 
-.aspect-\[4\/3\] {
-  aspect-ratio: 4/3;
-}
-
 .size-10 {
   width: 2.5rem;
   height: 2.5rem;
@@ -924,11 +905,6 @@ body {
 .size-5 {
   width: 1.25rem;
   height: 1.25rem;
-}
-
-.size-16 {
-  width: 4rem;
-  height: 4rem;
 }
 
 .h-5 {
@@ -967,20 +943,8 @@ body {
   height: 1px;
 }
 
-.h-24 {
-  height: 6rem;
-}
-
-.h-auto {
-  height: auto;
-}
-
 .max-h-\[500px\] {
   max-height: 500px;
-}
-
-.max-h-\[200px\] {
-  max-height: 200px;
 }
 
 .min-h-0 {
@@ -989,10 +953,6 @@ body {
 
 .min-h-\[55px\] {
   min-height: 55px;
-}
-
-.min-h-\[500px\] {
-  min-height: 500px;
 }
 
 .w-48 {
@@ -1005,10 +965,6 @@ body {
 
 .w-full {
   width: 100%;
-}
-
-.w-1\/2 {
-  width: 50%;
 }
 
 .min-w-\[400px\] {
@@ -1039,21 +995,17 @@ body {
   flex: 1 1 0%;
 }
 
-.flex-none {
-  flex: none;
-}
-
 .flex-grow {
   flex-grow: 1;
 }
 
-.-translate-y-1\/2 {
-  --tw-translate-y: -50%;
+.-translate-x-1\/2 {
+  --tw-translate-x: -50%;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
-.-translate-x-1\/2 {
-  --tw-translate-x: -50%;
+.-translate-y-1\/2 {
+  --tw-translate-y: -50%;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
@@ -1075,10 +1027,6 @@ body {
 
 .animate-spin {
   animation: spin 1s linear infinite;
-}
-
-.cursor-default {
-  cursor: default;
 }
 
 .cursor-not-allowed {
@@ -1105,20 +1053,8 @@ body {
   grid-template-columns: repeat(1, minmax(0, 1fr));
 }
 
-.grid-cols-\[1fr_2fr\] {
-  grid-template-columns: 1fr 2fr;
-}
-
-.grid-cols-2 {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
 .grid-rows-\[1fr_1fr\] {
   grid-template-rows: 1fr 1fr;
-}
-
-.grid-rows-\[auto_0px\] {
-  grid-template-rows: auto 0px;
 }
 
 .grid-rows-\[auto_1fr_auto\] {
@@ -1131,14 +1067,6 @@ body {
 
 .grid-rows-\[minmax\(0\2c 55px\)_minmax\(0\2c 1fr\)\] {
   grid-template-rows: minmax(0,55px) minmax(0,1fr);
-}
-
-.grid-rows-\[auto_1fr\] {
-  grid-template-rows: auto 1fr;
-}
-
-.grid-rows-2 {
-  grid-template-rows: repeat(2, minmax(0, 1fr));
 }
 
 .flex-col {
@@ -1280,40 +1208,16 @@ body {
   border-radius: 10px;
 }
 
-.rounded-md {
-  border-radius: calc(var(--radius) - 2px);
+.rounded-full {
+  border-radius: 9999px;
 }
 
 .rounded-none {
   border-radius: 0px;
 }
 
-.rounded-lg {
-  border-radius: var(--radius);
-}
-
-.rounded {
-  border-radius: 0.25rem;
-}
-
-.rounded-\[\] {
-  border-radius: ;
-}
-
-.rounded-full {
-  border-radius: 9999px;
-}
-
 .border {
   border-width: 1px;
-}
-
-.border-0 {
-  border-width: 0px;
-}
-
-.border-8 {
-  border-width: 8px;
 }
 
 .border-4 {
@@ -1322,10 +1226,6 @@ body {
 
 .border-b {
   border-bottom-width: 1px;
-}
-
-.border-l {
-  border-left-width: 1px;
 }
 
 .border-t {
@@ -1345,18 +1245,13 @@ body {
   border-color: rgb(229 231 235 / var(--tw-border-opacity));
 }
 
-.border-input {
-  border-color: hsl(var(--input));
-}
-
-.border-green-200 {
-  --tw-border-opacity: 1;
-  border-color: rgb(187 247 208 / var(--tw-border-opacity));
-}
-
 .border-green-500 {
   --tw-border-opacity: 1;
   border-color: rgb(34 197 94 / var(--tw-border-opacity));
+}
+
+.border-input {
+  border-color: hsl(var(--input));
 }
 
 .bg-\[\#0A66C2\] {
@@ -1371,10 +1266,6 @@ body {
 .bg-black {
   --tw-bg-opacity: 1;
   background-color: rgb(0 0 0 / var(--tw-bg-opacity));
-}
-
-.bg-border {
-  background-color: hsl(var(--border));
 }
 
 .bg-gray-100 {
@@ -1392,6 +1283,11 @@ body {
   background-color: rgb(249 250 251 / var(--tw-bg-opacity));
 }
 
+.bg-green-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(34 197 94 / var(--tw-bg-opacity));
+}
+
 .bg-muted {
   background-color: hsl(var(--muted));
 }
@@ -1399,15 +1295,6 @@ body {
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
-}
-
-.bg-green-500 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(34 197 94 / var(--tw-bg-opacity));
-}
-
-.bg-background\/80 {
-  background-color: hsl(var(--background) / 0.8);
 }
 
 .bg-opacity-50 {
@@ -1436,10 +1323,6 @@ body {
 
 .to-slate-700 {
   --tw-gradient-to: #334155 var(--tw-gradient-to-position);
-}
-
-.to-transparent {
-  --tw-gradient-to: transparent var(--tw-gradient-to-position);
 }
 
 .bg-clip-text {
@@ -1476,12 +1359,12 @@ body {
   padding: 1.25rem;
 }
 
-.p-8 {
-  padding: 2rem;
-}
-
 .p-6 {
   padding: 1.5rem;
+}
+
+.p-8 {
+  padding: 2rem;
 }
 
 .px-2 {
@@ -1642,6 +1525,11 @@ body {
   color: rgb(0 0 0 / var(--tw-text-opacity));
 }
 
+.text-blue-500 {
+  --tw-text-opacity: 1;
+  color: rgb(59 130 246 / var(--tw-text-opacity));
+}
+
 .text-destructive {
   color: hsl(var(--destructive));
 }
@@ -1680,6 +1568,10 @@ body {
   color: hsl(var(--muted-foreground));
 }
 
+.text-primary {
+  color: hsl(var(--primary));
+}
+
 .text-red-500 {
   --tw-text-opacity: 1;
   color: rgb(239 68 68 / var(--tw-text-opacity));
@@ -1704,15 +1596,6 @@ body {
   color: rgb(234 179 8 / var(--tw-text-opacity));
 }
 
-.text-blue-500 {
-  --tw-text-opacity: 1;
-  color: rgb(59 130 246 / var(--tw-text-opacity));
-}
-
-.text-primary {
-  color: hsl(var(--primary));
-}
-
 .no-underline {
   text-decoration-line: none;
 }
@@ -1734,12 +1617,6 @@ body {
 .shadow-sm {
   --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-
-.shadow-lg {
-  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -2030,29 +1907,6 @@ aside {
   color: #2E2F27;
 }
 
-.focus-within\:border-input:focus-within {
-  border-color: hsl(var(--input));
-}
-
-.focus-within\:outline-none:focus-within {
-  outline: 2px solid transparent;
-  outline-offset: 2px;
-}
-
-.focus-within\:ring-2:focus-within {
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-}
-
-.focus-within\:ring-ring:focus-within {
-  --tw-ring-color: hsl(var(--ring));
-}
-
-.focus-within\:ring-offset-2:focus-within {
-  --tw-ring-offset-width: 2px;
-}
-
 .hover\:border-black:hover {
   --tw-border-opacity: 1;
   border-color: rgb(0 0 0 / var(--tw-border-opacity));
@@ -2090,21 +1944,10 @@ aside {
   outline-offset: 2px;
 }
 
-.focus\:ring-2:focus {
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-}
-
 .focus\:ring-0:focus {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-}
-
-.focus\:ring-blue-500:focus {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(59 130 246 / var(--tw-ring-opacity));
 }
 
 .enabled\:hover\:opacity-80:hover:enabled {
@@ -2130,10 +1973,6 @@ aside {
 @media (min-width: 768px) {
   .md\:block {
     display: block;
-  }
-
-  .md\:grid-cols-\[minmax\(0\2c _45fr\)_minmax\(0\2c _15fr\)\] {
-    grid-template-columns: minmax(0, 45fr) minmax(0, 15fr);
   }
 
   .md\:text-2xl {

--- a/visual-retrieval-colpali/src/output.css
+++ b/visual-retrieval-colpali/src/output.css
@@ -971,6 +971,10 @@ body {
   min-width: 400px;
 }
 
+.min-w-\[300px\] {
+  min-width: 300px;
+}
+
 .max-w-4xl {
   max-width: 56rem;
 }
@@ -989,6 +993,14 @@ body {
 
 .max-w-screen-xl {
   max-width: 1280px;
+}
+
+.max-w-\[400px\] {
+  max-width: 400px;
+}
+
+.max-w-\[300px\] {
+  max-width: 300px;
 }
 
 .flex-1 {

--- a/visual-retrieval-colpali/src/static/js/settings.js
+++ b/visual-retrieval-colpali/src/static/js/settings.js
@@ -11,7 +11,7 @@ function initializeSettingsPage() {
     const questionsContainer = document.getElementById('questions-container');
     const addButton = document.getElementById('add-question');
     const rankerInputs = document.querySelectorAll('input[name="ranker"]');
-    const connectionInputs = document.querySelectorAll('input[name="vespa_token_id"], input[name="vespa_token_value"], input[name="gemini_token"]');
+    const connectionInputs = document.querySelectorAll('input[name="gemini_token"]');
     const applicationPackageInputs = document.querySelectorAll('input[name="tenant_name"], input[name="app_name"], textarea[name="schema"]');
     const promptTextarea = document.querySelector('textarea[name="prompt"]');
 
@@ -193,22 +193,18 @@ function updateRankerSaveButtonState() {
 }
 
 function updateConnectionSaveButtonState() {
-    const vespaTokenID = document.querySelector('input[name="vespa_token_id"]');
-    const vespaTokenValue = document.querySelector('input[name="vespa_token_value"]');
     const geminiToken = document.querySelector('input[name="gemini_token"]');
 
     const enabledButton = document.querySelector('#save-connection');
     const disabledButton = document.querySelector('#save-connection-disabled');
     const unsavedChanges = document.getElementById('connection-unsaved-changes');
 
-  if (!vespaTokenID || !vespaTokenValue || !geminiToken) return;
+  if (!geminiToken) return;
 
-    const isValid = vespaTokenID.value.trim() !== '' &&
-                    vespaTokenValue.value.trim() !== '' &&
-                    geminiToken.value.trim() !== '';
+    const isValid = geminiToken.value.trim() !== '';
 
     // Check if any field has changed from its original value
-    const hasChanges = [vespaTokenID, vespaTokenValue, geminiToken].some(input => {
+    const hasChanges = [geminiToken].some(input => {
         const originalValue = input.getAttribute('data-original') || '';
         return input.value.trim() !== originalValue.trim();
     });

--- a/visual-retrieval-colpali/src/static/js/settings.js
+++ b/visual-retrieval-colpali/src/static/js/settings.js
@@ -193,7 +193,7 @@ function updateUserRowNames() {
         if (usernameCell) {
             usernameCell.setAttribute('name', `username_${index}`);
         }
-    
+
     // Update password cell
     const passwordCell = row.querySelector('td[name^="password_"]');
     if (passwordCell) {
@@ -209,8 +209,8 @@ function updateUserSaveButtonState(is_deletion = false) {
     const inputs = usersContainer.querySelectorAll('input');
     var hasChanges = false;
     var hasIncompleteNewUser = false;
+    var hasDuplicateUsername = false;
 
-    // Handle deletion case first
     if (is_deletion) {
         hasChanges = true;
     } else {
@@ -220,20 +220,34 @@ function updateUserSaveButtonState(is_deletion = false) {
         });
     }
 
-    // Check for incomplete new user entries
     const userRows = document.querySelectorAll('#users-container tbody tr');
+    const usernames = new Set();
+    const duplicateUsernames = new Set();
+
     userRows.forEach((row) => {
+        const usernameCell = row.querySelector('td[name^="username_"]');
+        const passwordCell = row.querySelector('td[name^="password_"]');
+        const usernameInput = usernameCell.querySelector('input');
+        const passwordInput = passwordCell.querySelector('input');
+
+        const username = usernameInput ? usernameInput.value.trim() : usernameCell.textContent.trim();
+
         if (row.getAttribute('data-user-id') === 'new') {
-            const usernameInput = row.querySelector('td[name^="username_"] input');
-            const passwordInput = row.querySelector('td[name^="password_"] input');
-            
-            if (!usernameInput?.value.trim() || !passwordInput?.value.trim()) {
+            if (!username || !passwordInput?.value.trim()) {
                 hasIncompleteNewUser = true;
             }
         }
+
+        if (username) {
+            if (usernames.has(username.toLowerCase())) {
+                duplicateUsernames.add(username.toLowerCase());
+                hasDuplicateUsername = true;
+            }
+            usernames.add(username.toLowerCase());
+        }
     });
-    
-    if (hasChanges && !hasIncompleteNewUser) {
+
+    if (hasChanges && !hasIncompleteNewUser && !hasDuplicateUsername) {
         unsavedChanges.classList.remove('hidden');
         enabledButton.classList.remove('hidden');
         disabledButton.classList.add('hidden');
@@ -244,20 +258,20 @@ function updateUserSaveButtonState(is_deletion = false) {
             unsavedChanges.classList.add('hidden');
         }
     }
-    
+
     const form = document.createElement('form');
     let userIndex = 0;
     userRows.forEach((row) => {
         const usernameCell = row.querySelector('td[name^="username_"]');
         const passwordCell = row.querySelector('td[name^="password_"]');
         const userIdCell = row.querySelector('td[name^="user_id_"]');
-        
+
         const usernameInput = usernameCell.querySelector('input');
         const passwordInput = passwordCell.querySelector('input');
         const username = usernameInput ? usernameInput.value.trim() : usernameCell.textContent.trim();
         const password = passwordInput ? passwordInput.value.trim() : usernameCell.textContent.trim();
         const userId = userIdCell ? userIdCell.textContent.trim() : '';
-        
+
         if (username && password) {
             const usernameFormInput = document.createElement('input');
             usernameFormInput.type = 'hidden';
@@ -265,7 +279,7 @@ function updateUserSaveButtonState(is_deletion = false) {
             usernameFormInput.value = username;
             form.appendChild(usernameFormInput);
 
-            const passwordFormInput = document.createElement('input'); 
+            const passwordFormInput = document.createElement('input');
             passwordFormInput.type = 'hidden';
             passwordFormInput.name = `password_${userIndex}`;
             passwordFormInput.value = password;
@@ -303,7 +317,7 @@ document.addEventListener('click', function (e) {
         usernameCell.setAttribute('name', `username_${tableBody.children.length}`);
         usernameCell.className = 'p-4';
 
-        const passwordCell = document.createElement('td'); 
+        const passwordCell = document.createElement('td');
         passwordCell.setAttribute('name', `password_${tableBody.children.length}`);
         passwordCell.className = 'p-4';
 
@@ -344,7 +358,7 @@ document.addEventListener('click', function (e) {
         });
 
         const deleteButton = document.createElement('button');
-        deleteButton.className = 'delete-user ml-2';
+        deleteButton.className = 'delete-user ml-2 mt-2';
         deleteButton.setAttribute('variant', 'ghost');
         deleteButton.setAttribute('size', 'icon');
         deleteButton.innerHTML = `

--- a/visual-retrieval-colpali/src/static/js/settings.js
+++ b/visual-retrieval-colpali/src/static/js/settings.js
@@ -12,6 +12,7 @@ function initializeSettingsPage() {
     const addButton = document.getElementById('add-question');
     const rankerInputs = document.querySelectorAll('input[name="ranker"]');
     const connectionInputs = document.querySelectorAll('input[name="gemini_token"]');
+    const apiKeyFile = document.querySelector('input[name="api_key_file"]');
     const applicationPackageInputs = document.querySelectorAll('input[name="tenant_name"], input[name="app_name"], textarea[name="schema"]');
     const promptTextarea = document.querySelector('textarea[name="prompt"]');
 
@@ -38,6 +39,10 @@ function initializeSettingsPage() {
         input.setAttribute('data-original', input.value);
         input.addEventListener('input', updateConnectionSaveButtonState);
     });
+
+    if (apiKeyFile) {
+        apiKeyFile.addEventListener('change', updateConnectionSaveButtonState);
+    }
 
     if (connectionInputs.length > 0) {
         updateConnectionSaveButtonState();
@@ -194,20 +199,22 @@ function updateRankerSaveButtonState() {
 
 function updateConnectionSaveButtonState() {
     const geminiToken = document.querySelector('input[name="gemini_token"]');
+    const apiKeyFile = document.querySelector('input[name="api_key_file"]');
 
     const enabledButton = document.querySelector('#save-connection');
     const disabledButton = document.querySelector('#save-connection-disabled');
     const unsavedChanges = document.getElementById('connection-unsaved-changes');
 
-  if (!geminiToken) return;
+    if (!geminiToken || !apiKeyFile) return;
 
-    const isValid = geminiToken.value.trim() !== '';
+    const isValid = geminiToken.value.trim() !== '' &&
+                    (apiKeyFile.files.length > 0 || apiKeyFile.hasAttribute('data-has-file'));
 
     // Check if any field has changed from its original value
     const hasChanges = [geminiToken].some(input => {
         const originalValue = input.getAttribute('data-original') || '';
         return input.value.trim() !== originalValue.trim();
-    });
+    }) || apiKeyFile.files.length > 0;
 
     if (isValid) {
         enabledButton.classList.remove('hidden');

--- a/visual-retrieval-colpali/src/static/js/upload-documents.js
+++ b/visual-retrieval-colpali/src/static/js/upload-documents.js
@@ -44,6 +44,50 @@ document.addEventListener('htmx:afterRequest', function (event) {
   }
 });
 
+document.addEventListener('htmx:beforeRequest', function (event) {
+  if (event.detail.requestConfig.path.startsWith('/delete-document/')) {
+    isProcessing = true;
+    const modalContainer = document.createElement('div');
+    modalContainer.id = 'document-deleting-modal';
+    document.body.appendChild(modalContainer);
+
+    htmx.ajax('GET', '/document-deleting-modal', {
+      target: '#document-deleting-modal',
+      swap: 'innerHTML'
+    });
+  }
+});
+
+document.addEventListener('htmx:afterRequest', function (event) {
+  if (event.detail.requestConfig.path.startsWith('/delete-document/')) {
+    isProcessing = false;
+    const modalContainer = document.getElementById('document-deleting-modal');
+
+    if (modalContainer) {
+      try {
+        const response = JSON.parse(event.detail.xhr.response);
+
+        if (response.status === 'success') {
+          modalContainer.remove();
+          window.location.href = '/my-documents';
+        } else {
+          const errorMessage = response.message || 'An unknown error occurred';
+          htmx.ajax('GET', '/document-deleting-modal/error?message=' + encodeURIComponent(errorMessage), {
+            target: '#document-deleting-modal',
+            swap: 'innerHTML'
+          });
+        }
+      } catch (e) {
+        console.error('Error parsing response:', e);
+        htmx.ajax('GET', '/document-deleting-modal/error?message=' + encodeURIComponent('Failed to process server response'), {
+          target: '#document-deleting-modal',
+          swap: 'innerHTML'
+        });
+      }
+    }
+  }
+});
+
 window.addEventListener('beforeunload', function (e) {
   if (isProcessing) {
     e.preventDefault();

--- a/visual-retrieval-colpali/src/static/js/upload-documents.js
+++ b/visual-retrieval-colpali/src/static/js/upload-documents.js
@@ -1,0 +1,53 @@
+let isProcessing = false;
+
+document.addEventListener('htmx:beforeRequest', function (event) {
+  if (event.detail.requestConfig.path === '/upload-files') {
+    isProcessing = true;
+    const modalContainer = document.createElement('div');
+    modalContainer.id = 'document-processing-modal';
+    document.body.appendChild(modalContainer);
+
+    htmx.ajax('GET', '/document-processing-modal', {
+      target: '#document-processing-modal',
+      swap: 'innerHTML'
+    });
+  }
+});
+
+document.addEventListener('htmx:afterRequest', function (event) {
+  if (event.detail.requestConfig.path === '/upload-files') {
+    isProcessing = false;
+    const modalContainer = document.getElementById('document-processing-modal');
+
+    if (modalContainer) {
+      try {
+        const response = JSON.parse(event.detail.xhr.response);
+
+        if (response.status === 'success') {
+          modalContainer.remove();
+          window.location.href = '/my-documents';
+        } else {
+          const errorMessage = response.message || 'An unknown error occurred';
+          htmx.ajax('GET', '/document-processing-modal/error?message=' + encodeURIComponent(errorMessage), {
+            target: '#document-processing-modal',
+            swap: 'innerHTML'
+          });
+        }
+      } catch (e) {
+        console.error('Error parsing response:', e);
+        htmx.ajax('GET', '/document-processing-modal/error?message=' + encodeURIComponent('Failed to process server response'), {
+          target: '#document-processing-modal',
+          swap: 'innerHTML'
+        });
+      }
+    }
+  }
+});
+
+window.addEventListener('beforeunload', function (e) {
+  if (isProcessing) {
+    e.preventDefault();
+    e.returnValue = 'Document processing is in progress. Are you sure you want to leave?';
+    return e.returnValue;
+  }
+});


### PR DESCRIPTION
# Description

## Token removal

An input in the Connection settings will allow the user to upload its api-key file and avoid using tokens.

## Deploy and feed logic separation

Now when the deployment is performed, no document processing is done.

## Document management

To upload documents, the application must be deployed, from there, you can delete and upload documents without re-deploying the application.
The application also has to be deployed to delete documents. Now, the deletion logic removes the document from Vespa Cloud.
There are modals for document uploading and deletion, and their error alternatives. The process is now slower than before so the user needs to know what's going on.

# How to test

1. Run the DB separately.
2. Run the app and log in.
3. Assert that you cannot upload documents if the application isn't deployed.
4. Assert that you cannot deploy the application if an API key is not uploaded in the Connections tab.
5. Assert that the deployment process is now faster.
6. Assert that the document uploading now feeds the Vespa Cloud Environment.
7. Assert that the document deletion also deletes the document from Vespa (it shouldn't appear in the search results).

Closes #63
Closes #64
Closes #65
Closes #56
Closes #57 